### PR TITLE
当输入的句子不是例句时，提供有道翻译的机翻结果

### DIFF
--- a/iSearch/isearch.py
+++ b/iSearch/isearch.py
@@ -170,6 +170,32 @@ def get_text(url):
         text5 = re.sub('(\")', '\'', text5)
         expl += text5
 
+    # ------------------translation------------------
+
+    # If no '双语例句' found, then get translation
+
+    translation = soup.find('div', id='fanyiToggle')
+
+    ls6 = []
+
+    if translation:
+        for s in translation.descendants:
+            if isinstance(s, bs4.element.NavigableString):
+                if s.strip():
+                    ls6.append(s.strip())
+
+        text6 = '\n\n【有道翻译】\n\n'
+
+        for word in ls6:
+            if not word.startswith('以上为机器翻译结果'):
+                text6 = text6 + word + '\n\n'
+                continue
+            break
+
+        text6 = re.sub('(\")', '\'', text6)
+        expl += text6
+
+
     return expl
 
 


### PR DESCRIPTION
加入翻译功能

目前使用看来，发现只有词典中的例句才有翻译

比如
$ s hello from the outside
就不会有任何提示

俺加了功能后：
![image](https://user-images.githubusercontent.com/36079746/66739586-a1043c00-eea3-11e9-82b9-be61c863d28a.png)
